### PR TITLE
Don't use pointers for `Hints`

### DIFF
--- a/examples/infer_multiple_string_rows.go
+++ b/examples/infer_multiple_string_rows.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 
-	jtdinfer "github.com/bombsimon/jtd-infer-go"
+	"github.com/bombsimon/jtd-infer-go"
 )
 
 func main() {
@@ -12,7 +12,7 @@ func main() {
 		`{"name":"Jane", "age": 48, "something_nullable": null}`,
 	}
 	schema := jtdinfer.
-		InferStrings(rows, jtdinfer.NewHints()).
+		InferStrings(rows, jtdinfer.WithoutHints()).
 		IntoSchema()
 
 	j, _ := json.MarshalIndent(schema, "", "  ")

--- a/examples/infer_simple_value.go
+++ b/examples/infer_simple_value.go
@@ -3,12 +3,12 @@ package main
 import (
 	"encoding/json"
 
-	jtdinfer "github.com/bombsimon/jtd-infer-go"
+	"github.com/bombsimon/jtd-infer-go"
 )
 
 func main() {
 	schema := jtdinfer.
-		NewInferrer(jtdinfer.NewHints()).
+		NewInferrer(jtdinfer.WithoutHints()).
 		Infer("my-string").
 		IntoSchema()
 

--- a/examples/infer_with_hints.go
+++ b/examples/infer_with_hints.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 
-	jtdinfer "github.com/bombsimon/jtd-infer-go"
+	"github.com/bombsimon/jtd-infer-go"
 )
 
 func main() {
@@ -23,7 +23,7 @@ func main() {
 			"discriminator":[{"type":"s", "value":"foo"},{"type":"n", "value":3.14}]
 		}`,
 	}
-	hints := &jtdinfer.Hints{
+	hints := jtdinfer.Hints{
 		DefaultNumType: jtdinfer.NumTypeUint32,
 		Enums:          jtdinfer.NewHintSet().Add([]string{"work", "department"}),
 		Values:         jtdinfer.NewHintSet().Add([]string{"values"}),

--- a/hints.go
+++ b/hints.go
@@ -7,23 +7,19 @@ const Wildcard = "-"
 // values and discriminators.
 type Hints struct {
 	DefaultNumType NumType
-	Enums          *HintSet
-	Values         *HintSet
-	Discriminator  *HintSet
+	Enums          HintSet
+	Values         HintSet
+	Discriminator  HintSet
 }
 
-// NewHints creates a new empty non nil `Hints`.
-func NewHints() *Hints {
-	return &Hints{
-		Enums:         NewHintSet(),
-		Values:        NewHintSet(),
-		Discriminator: NewHintSet(),
-	}
+// WithoutHints is a shorthand to return empty hints.
+func WithoutHints() Hints {
+	return Hints{}
 }
 
 // SubHints will return the sub hints for all hint sets for the passed key.
-func (h Hints) SubHints(key string) *Hints {
-	return &Hints{
+func (h Hints) SubHints(key string) Hints {
+	return Hints{
 		DefaultNumType: h.DefaultNumType,
 		Enums:          h.Enums.SubHints(key),
 		Values:         h.Values.SubHints(key),
@@ -32,18 +28,18 @@ func (h Hints) SubHints(key string) *Hints {
 }
 
 // IsEnumActive checks if the enum hint set is active.
-func (h *Hints) IsEnumActive() bool {
+func (h Hints) IsEnumActive() bool {
 	return h.Enums.IsActive()
 }
 
 // IsValuesActive checks if the values hint set is active.
-func (h *Hints) IsValuesActive() bool {
+func (h Hints) IsValuesActive() bool {
 	return h.Values.IsActive()
 }
 
 // PeekActiveDiscriminator will peek the currently active discriminator, if any.
 // The returned boolean tells if there is an active discriminator.
-func (h *Hints) PeekActiveDiscriminator() (string, bool) {
+func (h Hints) PeekActiveDiscriminator() (string, bool) {
 	return h.Discriminator.PeekActive()
 }
 
@@ -53,21 +49,21 @@ type HintSet struct {
 }
 
 // NewHintSet creates a new empty `HintSet`.
-func NewHintSet() *HintSet {
-	return &HintSet{
+func NewHintSet() HintSet {
+	return HintSet{
 		Values: [][]string{},
 	}
 }
 
 // Add will add a path (slice) to the `HintSet`.
-func (h *HintSet) Add(v []string) *HintSet {
+func (h HintSet) Add(v []string) HintSet {
 	h.Values = append(h.Values, v)
 	return h
 }
 
 // SubHints will filter all the current sets and keep those who's first element
 // matches the passed key or wildcard.
-func (h *HintSet) SubHints(key string) *HintSet {
+func (h HintSet) SubHints(key string) HintSet {
 	filteredValues := [][]string{}
 
 	for _, values := range h.Values {
@@ -81,13 +77,13 @@ func (h *HintSet) SubHints(key string) *HintSet {
 		}
 	}
 
-	return &HintSet{
+	return HintSet{
 		Values: filteredValues,
 	}
 }
 
 // IsActive returns true if any set in the hint set his active.
-func (h *HintSet) IsActive() bool {
+func (h HintSet) IsActive() bool {
 	for _, valueList := range h.Values {
 		if len(valueList) == 0 {
 			return true
@@ -99,7 +95,7 @@ func (h *HintSet) IsActive() bool {
 
 // PeekActive returns the currently active value if any. The returned boolean
 // tells if a value was found.
-func (h *HintSet) PeekActive() (string, bool) {
+func (h HintSet) PeekActive() (string, bool) {
 	for _, values := range h.Values {
 		if len(values) != 1 {
 			continue

--- a/inferred_schema.go
+++ b/inferred_schema.go
@@ -64,9 +64,7 @@ func NewInferredSchema() *InferredSchema {
 // https://github.com/jsontypedef/json-typedef-infer/blob/master/src/inferred_schema.rs.
 // Since we don't have enums of this kind in Go we're using a struct with
 // pointers to a schema instead of wrapping the enums.
-func (i *InferredSchema) Infer(value any, hints *Hints) *InferredSchema {
-	hints = ensureHints(hints)
-
+func (i *InferredSchema) Infer(value any, hints Hints) *InferredSchema {
 	if value == nil {
 		return &InferredSchema{
 			SchemaType: SchemaTypeNullable,
@@ -316,7 +314,7 @@ func (i *InferredSchema) Infer(value any, hints *Hints) *InferredSchema {
 }
 
 // IntoSchema will convert an `InferredSchema` to a final `Schema`.
-func (i *InferredSchema) IntoSchema(hints *Hints) Schema {
+func (i *InferredSchema) IntoSchema(hints Hints) Schema {
 	switch i.SchemaType {
 	case SchemaTypeUnknown, SchemaTypeAny:
 		return Schema{}
@@ -388,24 +386,4 @@ func (i *InferredSchema) IntoSchema(hints *Hints) Schema {
 	}
 
 	return Schema{}
-}
-
-func ensureHints(hints *Hints) *Hints {
-	if hints == nil {
-		return NewHints()
-	}
-
-	if hints.Enums == nil {
-		hints.Enums = NewHintSet()
-	}
-
-	if hints.Values == nil {
-		hints.Values = NewHintSet()
-	}
-
-	if hints.Discriminator == nil {
-		hints.Discriminator = NewHintSet()
-	}
-
-	return hints
 }

--- a/inferrer.go
+++ b/inferrer.go
@@ -8,11 +8,11 @@ import (
 // hints used when inferring.
 type Inferrer struct {
 	Inference *InferredSchema
-	Hints     *Hints
+	Hints     Hints
 }
 
 // NewInferrer will create a new inferrer with a default `InferredSchema`.
-func NewInferrer(hints *Hints) *Inferrer {
+func NewInferrer(hints Hints) *Inferrer {
 	return &Inferrer{
 		Inference: NewInferredSchema(),
 		Hints:     hints,
@@ -37,7 +37,7 @@ func (i *Inferrer) IntoSchema() Schema {
 // the error occurred. If you already have the type of your data such as a slice
 // of numbers or a map of strings you can pass them directly to `Infer`. This is
 // just a convenience method if all you got is strings.
-func InferStrings(rows []string, hints *Hints) *Inferrer {
+func InferStrings(rows []string, hints Hints) *Inferrer {
 	inferrer := NewInferrer(hints)
 	if len(rows) == 0 {
 		return inferrer

--- a/inferrer_test.go
+++ b/inferrer_test.go
@@ -126,7 +126,7 @@ func TestInferString(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
-			gotSchema := InferStrings(tc.values, NewHints()).IntoSchema()
+			gotSchema := InferStrings(tc.values, WithoutHints()).IntoSchema()
 			assert.EqualValues(t, tc.expectedSchema, gotSchema)
 		})
 	}
@@ -252,7 +252,7 @@ func TestJTDInferWithDiscriminatorHints(t *testing.T) {
 
 func BenchmarkInferOneRowNoMissingHints(b *testing.B) {
 	wors := generateRows(1)
-	emptyHints := NewHints()
+	emptyHints := WithoutHints()
 
 	for n := 0; n < b.N; n++ {
 		InferStrings(wors, emptyHints)
@@ -261,7 +261,7 @@ func BenchmarkInferOneRowNoMissingHints(b *testing.B) {
 
 func BenchmarkInferThousandRowsNoMissingHints(b *testing.B) {
 	rows := generateRows(1000)
-	emptyHints := NewHints()
+	emptyHints := WithoutHints()
 
 	for n := 0; n < b.N; n++ {
 		InferStrings(rows, emptyHints)
@@ -270,15 +270,19 @@ func BenchmarkInferThousandRowsNoMissingHints(b *testing.B) {
 
 func BenchmarkInferOneRowMissingHints(b *testing.B) {
 	rows := generateRows(1)
+	hints := Hints{}
+
 	for n := 0; n < b.N; n++ {
-		InferStrings(rows, nil)
+		InferStrings(rows, hints)
 	}
 }
 
 func BenchmarkInferThousandRowsMissingHints(b *testing.B) {
 	rows := generateRows(1000)
+	hints := Hints{}
+
 	for n := 0; n < b.N; n++ {
-		InferStrings(rows, nil)
+		InferStrings(rows, hints)
 	}
 }
 

--- a/inferrer_test.go
+++ b/inferrer_test.go
@@ -249,3 +249,46 @@ func TestJTDInferWithDiscriminatorHints(t *testing.T) {
 
 	assert.EqualValues(t, expectedSchema, gotSchema)
 }
+
+func BenchmarkInferOneRowNoMissingHints(b *testing.B) {
+	wors := generateRows(1)
+	emptyHints := NewHints()
+
+	for n := 0; n < b.N; n++ {
+		InferStrings(wors, emptyHints)
+	}
+}
+
+func BenchmarkInferThousandRowsNoMissingHints(b *testing.B) {
+	rows := generateRows(1000)
+	emptyHints := NewHints()
+
+	for n := 0; n < b.N; n++ {
+		InferStrings(rows, emptyHints)
+	}
+}
+
+func BenchmarkInferOneRowMissingHints(b *testing.B) {
+	rows := generateRows(1)
+	for n := 0; n < b.N; n++ {
+		InferStrings(rows, nil)
+	}
+}
+
+func BenchmarkInferThousandRowsMissingHints(b *testing.B) {
+	rows := generateRows(1000)
+	for n := 0; n < b.N; n++ {
+		InferStrings(rows, nil)
+	}
+}
+
+func generateRows(n int) []string {
+	row := `{"name":"bench", "speed":100.2}`
+	rows := []string{}
+
+	for i := 0; i < n; i++ {
+		rows = append(rows, row)
+	}
+
+	return rows
+}

--- a/inferrer_test.go
+++ b/inferrer_test.go
@@ -251,11 +251,11 @@ func TestJTDInferWithDiscriminatorHints(t *testing.T) {
 }
 
 func BenchmarkInferOneRowNoMissingHints(b *testing.B) {
-	wors := generateRows(1)
+	rows := generateRows(1)
 	emptyHints := WithoutHints()
 
 	for n := 0; n < b.N; n++ {
-		InferStrings(wors, emptyHints)
+		InferStrings(rows, emptyHints)
 	}
 }
 
@@ -265,24 +265,6 @@ func BenchmarkInferThousandRowsNoMissingHints(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		InferStrings(rows, emptyHints)
-	}
-}
-
-func BenchmarkInferOneRowMissingHints(b *testing.B) {
-	rows := generateRows(1)
-	hints := Hints{}
-
-	for n := 0; n < b.N; n++ {
-		InferStrings(rows, hints)
-	}
-}
-
-func BenchmarkInferThousandRowsMissingHints(b *testing.B) {
-	rows := generateRows(1000)
-	hints := Hints{}
-
-	for n := 0; n < b.N; n++ {
-		InferStrings(rows, hints)
 	}
 }
 

--- a/inferrer_test.go
+++ b/inferrer_test.go
@@ -144,13 +144,13 @@ func TestJTDInfer(t *testing.T) {
 			"hobbies": {Elements: &Schema{Type: jtd.TypeString}},
 		},
 	}
-	gotSchema := InferStrings(rows, NewHints()).IntoSchema()
+	gotSchema := InferStrings(rows, WithoutHints()).IntoSchema()
 
 	assert.EqualValues(t, expectedSchema, gotSchema)
 }
 
 func TestJTDInferrerWithEnumHints(t *testing.T) {
-	hints := &Hints{
+	hints := Hints{
 		Enums: NewHintSet().
 			Add([]string{"name"}).
 			Add([]string{"address", "city"}),
@@ -198,7 +198,7 @@ func TestJTDInferrerWithEnumHints(t *testing.T) {
 }
 
 func TestJTDInferWithValuesHints(t *testing.T) {
-	hints := &Hints{
+	hints := Hints{
 		Values: NewHintSet().Add([]string{}),
 	}
 
@@ -220,7 +220,7 @@ func TestJTDInferWithValuesHints(t *testing.T) {
 }
 
 func TestJTDInferWithDiscriminatorHints(t *testing.T) {
-	hints := &Hints{
+	hints := Hints{
 		Discriminator: NewHintSet().Add([]string{"-", "type"}),
 	}
 


### PR DESCRIPTION
    Revert "Use pointers for `Hints` and `HintSet`"

    This reverts commit fe1b071fea20b93067f9373db546dd8320307ca8.

I converted the `Hints` to be pointers because `gocritic` (`hugeParam`) reports that the hints are 80 bytes and heavy to copy.

When using pointers instead we become sensitive to `nil` data and since the `Hints` holds pointers to `HintSets` we needed to add checks to ensure no values were actually left `nil`. I started to wonder how much this would cost compared to just copying the hints and wrote some benchmarks. These are the results:

## `Hints` is pointer

```sh
› go test -run XXX -bench .
goos: darwin
goarch: arm64
pkg: github.com/bombsimon/jtd-infer-go
BenchmarkInferOneRowNoMissingHints-10            1039881              1122 ns/op
BenchmarkInferThousandRowsNoMissingHints-10         1266            922018 ns/op
BenchmarkInferOneRowMissingHints-10               961521              1217 ns/op
BenchmarkInferThousandRowsMissingHints-10           1194           1009154 ns/op
PASS
ok      github.com/bombsimon/jtd-infer-go       5.832s
```

## `Hints` is copied

```sh
› go test -run XXX -bench .
goos: darwin
goarch: arm64
pkg: github.com/bombsimon/jtd-infer-go
BenchmarkInferOneRowNoMissingHints-10            1210305               995.1 ns/op
BenchmarkInferThousandRowsNoMissingHints-10         1512            776240 ns/op
BenchmarkInferOneRowMissingHints-10              1200474              1008 ns/op
BenchmarkInferThousandRowsMissingHints-10           1540            784011 ns/op
PASS
ok      github.com/bombsimon/jtd-infer-go       6.926s
```

Given this the code is much simpler and less fragile when not using pointers.
