### PR TITLE
Fix `Infer`, rename tests, add benchmark

### DIFF
--- a/inferred_number.go
+++ b/inferred_number.go
@@ -134,3 +134,34 @@ func (i *InferredNumber) ContainedBy(nt NumType) bool {
 
 	return minValue <= i.Min && maxValue >= i.Max
 }
+
+func anyAsNumber(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint8:
+		return float64(v), true
+	case uint16:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int8:
+		return float64(v), true
+	case int16:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0.0, false
+	}
+}

--- a/inferred_schema.go
+++ b/inferred_schema.go
@@ -83,9 +83,7 @@ func (i *InferredSchema) Infer(value any, hints Hints) *InferredSchema {
 		return &InferredSchema{SchemaType: SchemaTypeBoolean}
 	}
 
-	// In Go all numbers from unmarshalling JSON will be represented as float64
-	// so this is the only type we need.
-	if v, ok := value.(float64); ok && i.SchemaType == SchemaTypeUnknown {
+	if v, ok := anyAsNumber(value); ok && i.SchemaType == SchemaTypeUnknown {
 		return &InferredSchema{
 			SchemaType: SchemaTypeNumber,
 			Number:     NewNumber().Infer(v),
@@ -175,7 +173,7 @@ func (i *InferredSchema) Infer(value any, hints Hints) *InferredSchema {
 		return &InferredSchema{SchemaType: SchemaTypeAny}
 	}
 
-	if v, ok := value.(float64); ok && i.SchemaType == SchemaTypeNumber {
+	if v, ok := anyAsNumber(value); ok && i.SchemaType == SchemaTypeNumber {
 		return &InferredSchema{
 			SchemaType: SchemaTypeNumber,
 			Number:     i.Number.Infer(v),


### PR DESCRIPTION
- `Infer` can now handle numeric values that are not `float64`
- Add tests for `Infer` in addition to `InferStrings`
- Remove test with only one case and move to table
- Rename tests (drop `JTD`)
- Add benchmarking to see effects on new type switch

Fixes #8

---

### Benchmark with old code

```sh
goos: darwin
goarch: arm64
pkg: github.com/bombsimon/jtd-infer-go
cpu: Apple M1 Pro
BenchmarkInferOneRowNoMissingHints-10            1265922               938.8 ns/op
BenchmarkInferThousandRowsNoMissingHints-10         1436            786513 ns/op
BenchmarkInferSimpleString-10                   14812551                78.60 ns/op
PASS
ok      github.com/bombsimon/jtd-infer-go       4.587s
```

### Benchmark with new code

```sh
goos: darwin
goarch: arm64
pkg: github.com/bombsimon/jtd-infer-go
cpu: Apple M1 Pro
BenchmarkInferOneRowNoMissingHints-10            1256799               943.4 ns/op
BenchmarkInferThousandRowsNoMissingHints-10         1501            793621 ns/op
BenchmarkInferSimpleString-10                   14489355                78.98 ns/op
PASS
ok      github.com/bombsimon/jtd-infer-go       4.836s
```

No noticeable performance drop.